### PR TITLE
CU-frpfc9 fix xcode 12, building for iOS Simulator, but linking in ob…

### DIFF
--- a/ElastosDIDSDK.xcodeproj/project.pbxproj
+++ b/ElastosDIDSDK.xcodeproj/project.pbxproj
@@ -1500,6 +1500,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -1542,6 +1543,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",


### PR DESCRIPTION
…ject file built for iOS, for architecture arm64